### PR TITLE
chore: scaffold nx workspace with angular registration app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.tmp/
+
+# Angular generated
+/apps/registration/.angular/

--- a/apps/registration/project.json
+++ b/apps/registration/project.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "registration",
+  "projectType": "application",
+  "sourceRoot": "apps/registration/src",
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:build",
+      "options": {
+        "outputPath": "dist/apps/registration",
+        "main": "apps/registration/src/main.ts",
+        "tsConfig": "apps/registration/tsconfig.app.json",
+        "assets": ["apps/registration/src/favicon.ico", "apps/registration/src/assets"],
+        "bundler": "vite"
+      }
+    },
+    "serve": {
+      "executor": "@nx/angular:serve",
+      "options": {
+        "buildTarget": "registration:build",
+        "hmr": true
+      }
+    },
+    "test": {
+      "executor": "@nx/angular:vitest",
+      "options": {
+        "vitestConfig": "apps/registration/vitest.config.ts"
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/registration/src/app/app.component.spec.ts
+++ b/apps/registration/src/app/app.component.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest';
+import { AppComponent } from './app.component';
+
+test('should create the app', () => {
+  const app = new AppComponent();
+  expect(app).toBeTruthy();
+});

--- a/apps/registration/src/app/app.component.ts
+++ b/apps/registration/src/app/app.component.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'hns-root',
+  standalone: true,
+  imports: [FormsModule],
+  template: `
+    <h1>Register for HNS</h1>
+    <form (submit)="register($event)">
+      <label>
+        Name
+        <input name="name" [(ngModel)]="name" required />
+      </label>
+      <label>
+        Email
+        <input name="email" [(ngModel)]="email" required />
+      </label>
+      <button type="submit">Create Passkey</button>
+    </form>
+    <p *ngIf="message">{{ message }}</p>
+  `
+})
+export class AppComponent {
+  name = '';
+  email = '';
+  message = '';
+
+  async register(event: Event) {
+    event.preventDefault();
+    try {
+      const publicKey: PublicKeyCredentialCreationOptions = {
+        challenge: new Uint8Array(32),
+        rp: { name: 'HNS' },
+        user: {
+          id: new TextEncoder().encode(this.email),
+          name: this.name,
+          displayName: this.name
+        },
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+        authenticatorSelection: {
+          userVerification: 'required'
+        },
+        timeout: 60000,
+        attestation: 'none'
+      };
+      await navigator.credentials.create({ publicKey });
+      this.message = 'Passkey created. HNS ID registered.';
+    } catch (err) {
+      console.error(err);
+      this.message = 'Registration failed.';
+    }
+  }
+}

--- a/apps/registration/src/index.html
+++ b/apps/registration/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>HNS Registration</title>
+    <base href="/" />
+  </head>
+  <body>
+    <hns-root></hns-root>
+  </body>
+</html>

--- a/apps/registration/src/main.ts
+++ b/apps/registration/src/main.ts
@@ -1,0 +1,7 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter([])]
+}).catch(err => console.error(err));

--- a/apps/registration/src/styles.css
+++ b/apps/registration/src/styles.css
@@ -1,0 +1,8 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+label {
+  display: block;
+  margin-bottom: 1rem;
+}

--- a/apps/registration/tsconfig.app.json
+++ b/apps/registration/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/apps/registration/vite.config.ts
+++ b/apps/registration/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { nxAngularVitePlugin } from '@nx/angular/vite';
+
+export default defineConfig(() => ({
+  plugins: [nxAngularVitePlugin({})],
+}));

--- a/apps/registration/vitest.config.ts
+++ b/apps/registration/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "npmScope": "hns",
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "@nx/js/tasks-runner",
+      "options": {
+        "cacheableOperations": ["build", "test", "lint", "e2e"]
+      }
+    }
+  },
+  "workspaceLayout": {
+    "appsDir": "apps",
+    "libsDir": "libs"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hns",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "start": "nx serve registration",
+    "build": "nx build registration",
+    "test": "nx test registration"
+  },
+  "devDependencies": {
+    "nx": "^19.8.0",
+    "@nx/angular": "^19.8.0",
+    "@angular/cli": "^20.0.0",
+    "typescript": "~5.4.0"
+  },
+  "dependencies": {
+    "@angular/core": "^20.0.0",
+    "@angular/common": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
+    "@angular/platform-browser-dynamic": "^20.0.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.6.0",
+    "zone.js": "~0.14.0",
+    "@angular/router": "^20.0.0"
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2020",
+    "lib": ["ES2022", "DOM"],
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@hns/*": ["libs/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Nx workspace configuration
- add Angular Vite registration app with WebAuthn passkey setup

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: nx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1870fec94832895b5bdd7ca47b6ba